### PR TITLE
Add subscription & signals features

### DIFF
--- a/projectinsight/scripts/dashboard.js
+++ b/projectinsight/scripts/dashboard.js
@@ -2220,44 +2220,42 @@ async function loadConvertPage() {
 
 async function loadSubscribePage() {
   return `
-    <div class="card">
-      <div class="card-header">
-        <h2 class="card-title">Subscription Plans</h2>
+    <div class="subscribe-container">
+      <div class="page-header fade-in">
+        <h2 class="page-title">Subscription Plans</h2>
+        <p class="page-subtitle">Choose a plan to start earning</p>
       </div>
-      <div class="card-body">
-        <div class="stats-grid">
-          <div class="stat-card">
-            <div class="stat-icon">
-              <i class="material-icons">stars</i>
+      <div class="subscribe-stats fade-in">
+        <div class="subscribe-stat-card">
+          <div class="subscribe-stat-value" id="subscriptionBalance">$0.00</div>
+          <div class="subscribe-stat-label">Subscription Balance</div>
+        </div>
+        <div class="subscribe-stat-card">
+          <button class="btn btn-secondary w-100" id="viewSubscriptionsBtn">
+            <i class="material-icons">visibility</i>
+            View history
+          </button>
+        </div>
+      </div>
+      <div class="plans-grid fade-in" id="subscriptionPlans"></div>
+    </div>
+
+    <div class="modal-overlay" id="subscribeModalOverlay" style="display:none;">
+      <div class="side-modal wide-modal active" id="subscribeModal">
+        <div class="modal-header">
+          <h2 id="subscribeModalTitle">Subscribe</h2>
+          <button class="close-modal" id="closeSubscribeModal"><i class="material-icons">close</i></button>
+        </div>
+        <div class="modal-content">
+          <form id="subscribeForm">
+            <div class="form-group">
+              <label>Amount:</label>
+              <input type="number" id="subscribeAmount" class="form-control" min="0" step="any" required />
             </div>
-            <div class="stat-value">Free</div>
-            <div class="stat-label">Basic Trading</div>
-            <div style="margin-top: 1rem;">
-              <button class="btn btn-secondary w-100">Current Plan</button>
-            </div>
-          </div>
-          
-          <div class="stat-card" style="border-color: var(--accent-color);">
-            <div class="stat-icon">
-              <i class="material-icons">diamond</i>
-            </div>
-            <div class="stat-value">$29</div>
-            <div class="stat-label">Pro Trading</div>
-            <div style="margin-top: 1rem;">
-              <button class="btn btn-primary w-100">Upgrade</button>
-            </div>
-          </div>
-          
-          <div class="stat-card">
-            <div class="stat-icon">
-              <i class="material-icons">workspace_premium</i>
-            </div>
-            <div class="stat-value">$99</div>
-            <div class="stat-label">Premium</div>
-            <div style="margin-top: 1rem;">
-              <button class="btn btn-primary w-100">Upgrade</button>
-            </div>
-          </div>
+            <button type="submit" class="btn btn-primary w-100" id="confirmSubscribeBtn">
+              <i class="material-icons">check</i> Confirm
+            </button>
+          </form>
         </div>
       </div>
     </div>
@@ -2266,22 +2264,36 @@ async function loadSubscribePage() {
 
 async function loadSignalsPage() {
   return `
-    <div class="card">
-      <div class="card-header">
-        <h2 class="card-title">Trading Signals</h2>
+    <div class="signal-container">
+      <div class="page-header fade-in">
+        <h2 class="page-title">Signals</h2>
+        <p class="page-subtitle">Purchase premium trading signals</p>
       </div>
-      <div class="card-body">
-        <div class="text-center">
-          <i class="material-icons" style="font-size: 4rem; color: var(--accent-color); margin-bottom: 1rem;">wifi</i>
-          <h3>Trading Signals</h3>
-          <p class="text-muted">Get real-time trading signals from our AI-powered system</p>
-          <p class="text-muted">Coming soon...</p>
-          <div style="margin-top: 2rem;">
-            <button class="btn btn-primary">
-              <i class="material-icons">notifications</i>
-              Get Notified When Available
-            </button>
-          </div>
+      <div class="signal-stats fade-in">
+        <div class="signal-stat-card">
+          <div class="signal-stat-value" id="signalBalance">$0.00</div>
+          <div class="signal-stat-label">Signal Balance</div>
+        </div>
+        <div class="signal-stat-card">
+          <button class="btn btn-secondary w-100" id="viewSignalsBtn">
+            <i class="material-icons">visibility</i>
+            View history
+          </button>
+        </div>
+      </div>
+      <div class="signals-grid fade-in" id="signalPackages"></div>
+    </div>
+
+    <div class="modal-overlay" id="signalModalOverlay" style="display:none;">
+      <div class="side-modal wide-modal active" id="signalModal">
+        <div class="modal-header">
+          <h2 id="signalModalTitle">Buy Signal</h2>
+          <button class="close-modal" id="closeSignalModal"><i class="material-icons">close</i></button>
+        </div>
+        <div class="modal-content">
+          <button class="btn btn-primary w-100" id="confirmSignalBtn">
+            <i class="material-icons">shopping_cart</i> Purchase
+          </button>
         </div>
       </div>
     </div>
@@ -2666,9 +2678,19 @@ async function initializePageFunctionality(page) {
       }
       break;
     case 'subscribe':
+      await loadScript('../scripts/subscribe.js');
+      if (window.initializeSubscribePage) {
+        await window.initializeSubscribePage();
+      }
+      break;
     case 'signals':
+      await loadScript('../scripts/signals.js');
+      if (window.initializeSignalsPage) {
+        await window.initializeSignalsPage();
+      }
+      break;
     case 'experts':
-      // These pages don't need special initialization yet
+      // No special initialization
       break;
     default:
       console.log(`No special initialization needed for ${page}`);

--- a/projectinsight/scripts/signals.js
+++ b/projectinsight/scripts/signals.js
@@ -1,0 +1,68 @@
+const SignalsPage = {
+  packages: [],
+  userCurrency: 'USD',
+  fiatBalance: 0,
+  currentPkg: null,
+  async init(){
+    await this.fetchData();
+    this.renderPackages();
+    this.setup();
+  },
+  async fetchData(){
+    const res = await fetch(`/api/user/${window.currentUser.id}/signal-overview`, {credentials:'include'});
+    if(res.ok){
+      const data = await res.json();
+      this.packages = data.packages || [];
+      this.userCurrency = data.userCurrency;
+      this.fiatBalance = data.fiatBalance || 0;
+      this.userSignals = data.userSignals || [];
+    }
+  },
+  renderPackages(){
+    const container=document.getElementById('signalPackages');
+    if(!container) return;
+    const currency=this.userCurrency;
+    container.innerHTML=this.packages.map(p=>{
+      const sig = this.userSignals.find(s=>s.signalName===p.name);
+      const bal = sig ? parseFloat(sig.balance) : 0;
+      return `<div class="stake-pool-card">
+        <div class="pool-header"><h3>${p.name}</h3></div>
+        <div class="pool-details">
+          <div class="pool-detail"><span class="detail-label">Signal price</span><span class="detail-value">${p.price} ${currency}</span></div>
+          <div class="pool-detail"><span class="detail-label">Signal strength</span><span class="roi-badge">${p.strength}%</span></div>
+          <div class="pool-detail"><span class="detail-label">Current balance</span><span class="detail-value">${bal} ${currency}</span></div>
+        </div>
+        <button class="stake-button" onclick="SignalsPage.open(${p.id})">Buy</button>
+      </div>`;
+    }).join('');
+    document.getElementById('signalBalance').textContent = `${currency}${this.fiatBalance.toFixed(2)}`;
+  },
+  setup(){
+    const overlay=document.getElementById('signalModalOverlay');
+    const closeBtn=document.getElementById('closeSignalModal');
+    if(closeBtn) closeBtn.onclick=()=>{overlay.style.display='none';};
+    overlay.addEventListener('click',(e)=>{if(e.target===overlay)overlay.style.display='none';});
+    document.getElementById('confirmSignalBtn').onclick=this.purchase.bind(this);
+  },
+  open(id){
+    this.currentPkg=this.packages.find(p=>p.id===id);
+    if(!this.currentPkg) return;
+    document.getElementById('signalModalTitle').textContent=`Buy ${this.currentPkg.name}`;
+    document.getElementById('signalModalOverlay').style.display='block';
+  },
+  async purchase(){
+    if(!this.currentPkg) return;
+    const res = await fetch('/api/signals/purchase',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({userId:window.currentUser.id,packageId:this.currentPkg.id})});
+    if(res.ok){
+      alert('Signal purchased');
+      document.getElementById('signalModalOverlay').style.display='none';
+      await this.fetchData();
+      this.renderPackages();
+    }else{
+      const d=await res.json();
+      alert(d.error||'Error');
+    }
+  }
+};
+
+window.initializeSignalsPage = function(){ SignalsPage.init(); };

--- a/projectinsight/scripts/subscribe.js
+++ b/projectinsight/scripts/subscribe.js
@@ -1,0 +1,75 @@
+const SubscribePage = {
+  plans: [],
+  userCurrency: 'USD',
+  fiatBalance: 0,
+  currentPlan: null,
+  init: async function() {
+    await this.fetchData();
+    this.renderPlans();
+    this.setup();
+  },
+  fetchData: async function() {
+    const res = await fetch(`/api/user/${window.currentUser.id}/subscription-overview`, { credentials: 'include' });
+    if(res.ok){
+      const data = await res.json();
+      this.plans = data.plans || [];
+      this.userCurrency = data.userCurrency;
+      this.fiatBalance = data.fiatBalance || 0;
+      this.userSubs = data.userSubscriptions || [];
+    }
+  },
+  renderPlans: function() {
+    const container = document.getElementById('subscriptionPlans');
+    if(!container) return;
+    const currency = this.userCurrency;
+    container.innerHTML = this.plans.map(p=>{
+      const sub = this.userSubs.find(s=>s.planName===p.name);
+      const bal = sub ? parseFloat(sub.balance) : 0;
+      return `
+        <div class="stake-pool-card">
+          <div class="pool-header"><h3>${p.name}</h3></div>
+          <div class="pool-details">
+            <div class="pool-detail"><span class="detail-label">Minimum</span><span class="detail-value">${p.minimum} ${currency}</span></div>
+            <div class="pool-detail"><span class="detail-label">Maximum</span><span class="detail-value">${p.maximum} ${currency}</span></div>
+            <div class="pool-detail"><span class="detail-label">Duration</span><span class="detail-value">${p.duration} days</span></div>
+            <div class="pool-detail"><span class="detail-label">ROI</span><span class="roi-badge">${p.roi}%</span></div>
+            <div class="pool-detail"><span class="detail-label">Current Balance</span><span class="detail-value">${bal} ${currency}</span></div>
+          </div>
+          <button class="stake-button" onclick="SubscribePage.open(${p.id})">Subscribe</button>
+        </div>`;
+    }).join('');
+    document.getElementById('subscriptionBalance').textContent = `${currency}${this.fiatBalance.toFixed(2)}`;
+  },
+  setup: function(){
+    const overlay=document.getElementById('subscribeModalOverlay');
+    const closeBtn=document.getElementById('closeSubscribeModal');
+    if(closeBtn) closeBtn.onclick=()=>{overlay.style.display='none';};
+    overlay.addEventListener('click',(e)=>{if(e.target===overlay)overlay.style.display='none';});
+    const form=document.getElementById('subscribeForm');
+    form.addEventListener('submit', this.submit.bind(this));
+  },
+  open: function(planId){
+    this.currentPlan = this.plans.find(p=>p.id===planId);
+    if(!this.currentPlan) return;
+    document.getElementById('subscribeModalTitle').textContent = `Subscribe ${this.currentPlan.name}`;
+    document.getElementById('subscribeAmount').value = this.currentPlan.minimum;
+    document.getElementById('subscribeModalOverlay').style.display='block';
+  },
+  submit: async function(e){
+    e.preventDefault();
+    if(!this.currentPlan) return;
+    const amount=parseFloat(document.getElementById('subscribeAmount').value);
+    const res = await fetch('/api/subscriptions',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({userId:window.currentUser.id,planId:this.currentPlan.id,amount})});
+    if(res.ok){
+      alert('Subscription created');
+      document.getElementById('subscribeModalOverlay').style.display='none';
+      await this.fetchData();
+      this.renderPlans();
+    }else{
+      const d=await res.json();
+      alert(d.error||'Error');
+    }
+  }
+};
+
+window.initializeSubscribePage = function(){ SubscribePage.init(); };


### PR DESCRIPTION
## Summary
- add DB tables for subscription and signal tracking
- credit referrers when deposits confirm
- implement APIs for subscription plans, signal packages, and referral withdrawal
- update dashboard to load new pages and add JS handlers
- add frontend scripts for Subscribe and Signals pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684cbfa7b264832bb92fb9572d96064a